### PR TITLE
Fix extra event key for notifications

### DIFF
--- a/app/src/main/java/khw15/eventsdicoding/ui/NotificationsWorker.kt
+++ b/app/src/main/java/khw15/eventsdicoding/ui/NotificationsWorker.kt
@@ -32,7 +32,7 @@ class NotificationsWorker(
 
     companion object {
         private val TAG = NotificationsWorker::class.java.simpleName
-        const val EXTRA_EVENT = "EventForDicoding"
+        const val EXTRA_EVENT = "EventsForDicoding"
         const val NOTIFICATION_ID = 25
         const val CHANNEL_ID = "25152515"
     }


### PR DESCRIPTION
## Summary
- fix notification worker extra key to `EventsForDicoding`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy: HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6898321289d08325a41f3ff11755aeb9