### PR TITLE
Fix extra key and DAO deletion semantics, add Room unit test

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -78,6 +78,9 @@ dependencies {
     implementation(libs.androidx.activity)
     implementation(libs.androidx.constraintlayout)
     testImplementation(libs.junit)
+    testImplementation(libs.androidx.test.core)
+    testImplementation(libs.androidx.arch.core.testing)
+    testImplementation(libs.robolectric)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
 

--- a/app/src/main/java/khw15/eventsdicoding/data/local/room/EventDao.kt
+++ b/app/src/main/java/khw15/eventsdicoding/data/local/room/EventDao.kt
@@ -68,8 +68,9 @@ interface EventDao {
     @Update
     suspend fun updateEvent(event: EventEntity)
 
+    // Deletes all events that are not marked as favorites
     @Query("DELETE FROM Events_For_Dicoding WHERE isFavorite = 0")
-    suspend fun deleteAll()
+    suspend fun deleteNonFavoriteEvents()
 
     // --- Favorite State Check ---
 

--- a/app/src/main/java/khw15/eventsdicoding/ui/NotificationsWorker.kt
+++ b/app/src/main/java/khw15/eventsdicoding/ui/NotificationsWorker.kt
@@ -32,7 +32,7 @@ class NotificationsWorker(
 
     companion object {
         private val TAG = NotificationsWorker::class.java.simpleName
-        const val EXTRA_EVENT = "EventForDicoding"
+        const val EXTRA_EVENT = "EventsForDicoding"
         const val NOTIFICATION_ID = 25
         const val CHANNEL_ID = "25152515"
     }

--- a/app/src/test/java/khw15/eventsdicoding/ExampleUnitTest.kt
+++ b/app/src/test/java/khw15/eventsdicoding/ExampleUnitTest.kt
@@ -1,17 +1,95 @@
 package khw15.eventsdicoding
 
+import android.content.Context
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.Observer
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import khw15.eventsdicoding.data.local.entity.EventEntity
+import khw15.eventsdicoding.data.local.room.EventDao
+import khw15.eventsdicoding.data.local.room.EventDatabase
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+import kotlin.test.assertEquals
 
-import org.junit.Assert.*
-
-/**
- * Example local unit test, which will execute on the development machine (host).
- *
- * See [testing documentation](http://d.android.com/tools/testing).
- */
 class ExampleUnitTest {
+
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    private lateinit var database: EventDatabase
+    private lateinit var dao: EventDao
+
+    @Before
+    fun initDb() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        database = Room.inMemoryDatabaseBuilder(context, EventDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        dao = database.eventDao()
+    }
+
+    @After
+    fun closeDb() {
+        database.close()
+    }
+
     @Test
-    fun addition_isCorrect() {
-        assertEquals(4, 2 + 2)
+    fun insertFavoriteEvent_andRetrieve() = runBlocking {
+        val event = EventEntity(
+            id = 1,
+            name = "Sample Event",
+            summary = null,
+            description = null,
+            imageLogo = null,
+            mediaCover = null,
+            category = null,
+            ownerName = null,
+            cityName = null,
+            quota = null,
+            registrants = null,
+            beginTime = null,
+            endTime = null,
+            link = null,
+            isFavorite = true,
+            isUpcoming = null,
+            isFinished = null,
+        )
+
+        dao.insertEvents(listOf(event))
+        val favorites = dao.getFavoriteEvents().getOrAwaitValue()
+
+        assertEquals(listOf(event), favorites)
+    }
+
+    private fun <T> LiveData<T>.getOrAwaitValue(
+        time: Long = 2,
+        timeUnit: TimeUnit = TimeUnit.SECONDS
+    ): T {
+        var data: T? = null
+        val latch = CountDownLatch(1)
+        val observer = object : Observer<T> {
+            override fun onChanged(o: T) {
+                data = o
+                latch.countDown()
+                this@getOrAwaitValue.removeObserver(this)
+            }
+        }
+
+        this.observeForever(observer)
+
+        if (!latch.await(time, timeUnit)) {
+            throw TimeoutException("LiveData value was never set.")
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        return data as T
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,6 +33,9 @@ lifecycleViewmodelKtx = "2.6.2"
 #noinspection GradleDependency
 roomKtx = "2.5.2"
 workRuntime = "2.10.0"
+testCore = "1.6.1"
+coreTesting = "2.2.0"
+robolectric = "4.13"
 
 [libraries]
 aboutlibraries = { module = "com.mikepenz:aboutlibraries", version.ref = "aboutlibraries" }
@@ -65,6 +68,9 @@ androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "
 androidx-lifecycle-livedata-ktx = { module = "androidx.lifecycle:lifecycle-livedata-ktx", version.ref = "lifecycleLivedataKtx" }
 androidx-lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "lifecycleViewmodelKtx" }
 androidx-room-ktx = { module = "androidx.room:room-ktx", version.ref = "roomKtx" }
+androidx-test-core = { module = "androidx.test:core", version.ref = "testCore" }
+androidx-arch-core-testing = { module = "androidx.arch.core:core-testing", version.ref = "coreTesting" }
+robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- correct notification extra key to `EventsForDicoding`
- rename `deleteAll` to `deleteNonFavoriteEvents` to clarify behavior
- add in-memory Room unit test and supporting test dependencies

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689833bca1ec83258d4d6493d9e4c7b2